### PR TITLE
typo in gemma-it.jinja

### DIFF
--- a/chat_templates/gemma-it.jinja
+++ b/chat_templates/gemma-it.jinja
@@ -5,7 +5,7 @@
     {% set loop_messages = messages %}
     {% set system_message = '' %}
 {% endif %}
-{% for message in messages %}
+{% for message in loop_messages %}
     {% if (message['role'] == 'user') != (loop.index0 % 2 == 0) %}
         {{ raise_exception('Conversation roles must alternate user/assistant/user/assistant/...') }}
     {% endif %}


### PR DESCRIPTION
Hi!

This PR fixes a typo in the Gemma template: it was iterating on all messages including the `system` one triggering a `Conversation roles must alternate user/assistant/user/assistant/...` error.