### PR TITLE
Update saiga.jinja

### DIFF
--- a/chat_templates/saiga.jinja
+++ b/chat_templates/saiga.jinja
@@ -18,6 +18,6 @@
     {{ bos_token + message['role'] + '\n' + message['content'].strip() + eos_token }}
 
     {% if loop.last and message['role'] == 'user' and add_generation_prompt %}
-        {{ bos_token + 'bot\n' }}
+        {{ bos_token + 'bot' }}
     {% endif %}
 {% endfor %}


### PR DESCRIPTION
Hello, I was trying to use this template with vLLM as inference engine and here is why I decided to remove \n from the end:

Here is my request:
![telegram-cloud-photo-size-2-5251674538700300267-y](https://github.com/chujiezheng/chat_templates/assets/41271764/2217ca27-a766-4556-b75d-63c11fcffc32)

Here is the original answer without the change:
![telegram-cloud-photo-size-2-5251674538700300269-y](https://github.com/chujiezheng/chat_templates/assets/41271764/a3b536d9-c8d3-41dd-91e9-8208f205db1b)

Here is the answer after removing "\n"

![telegram-cloud-photo-size-2-5251674538700300268-y](https://github.com/chujiezheng/chat_templates/assets/41271764/9c58bcf9-94a4-44c2-ac09-b29f7d504151)

I tried that several times and results are the same (with \n it generates completely mess)

This is the model, which was used for testing: https://huggingface.co/Vikhrmodels/Vikhr-7B-instruct_0.2
It uses the same processing as original saiga (the model itself is built upon saiga)

Thank you for ur amazing repo!  