### PR TITLE
Two Stop Tokens of Llama3

### DIFF
--- a/chat_templates/llama-3-chat.jinja
+++ b/chat_templates/llama-3-chat.jinja
@@ -9,7 +9,7 @@
 
 {% for message in loop_messages %}
     {% if (message['role'] == 'user') != (loop.index0 % 2 == 0) %}
-        {{ raise_exception('Conversation roles must alternate user/bot/user/bot/...') }}
+        {{ raise_exception('Conversation roles must alternate user/assistant/user/assistant/...') }}
     {% endif %}
 
     {% if loop.index0 == 0 %}

--- a/generation_configs/llama-3-chat.json
+++ b/generation_configs/llama-3-chat.json
@@ -1,6 +1,6 @@
 {
     "chat_template": "chat_templates/llama-3-chat.jinja",
     "stop_str": null,
-    "stop_token_ids": [128009],
+    "stop_token_ids": [128001, 128009],
     "system_prompt": "You are a helpful, respectful and honest assistant. Always answer as helpfully as possible, while being safe. Your answers should not include any harmful, unethical, racist, sexist, toxic, dangerous, or illegal content. Please ensure that your responses are socially unbiased and positive in nature.\n\nIf a question does not make any sense, or is not factually coherent, explain why instead of answering something not correct. If you don't know the answer to a question, please don't share false information."
 }


### PR DESCRIPTION
@chujiezheng LLama-3 has two stop tokens: `<|end_of_text|>` ([id 128001](https://huggingface.co/NousResearch/Meta-Llama-3-8B-Instruct/blob/main/tokenizer_config.json#L11)) and `<|eot_id|>` (id 128009). And, as far as I understood (looking at the [discussion here](https://github.com/vllm-project/vllm/issues/4180)), the correct way to handle this is to specify both of them in the generation config file.