### PR TITLE
fix: update the template for gemma-it

### DIFF
--- a/chat_templates/gemma-it.jinja
+++ b/chat_templates/gemma-it.jinja
@@ -1,19 +1,11 @@
+{{ bos_token }}
 {% if messages[0]['role'] == 'system' %}
-    {% set system_message = messages[0]['content'] | trim + '\n\n' %}
-    {% set messages = messages[1:] %}
-{% else %}
-    {% set system_message = '' %}
+    {{ raise_exception('System role not supported') }}
 {% endif %}
 
 {% for message in messages %}
     {% if (message['role'] == 'user') != (loop.index0 % 2 == 0) %}
         {{ raise_exception('Conversation roles must alternate user/assistant/user/assistant/...') }}
-    {% endif %}
-
-    {% if loop.index0 == 0 %}
-        {% set content = system_message + message['content'] %}
-    {% else %}
-        {% set content = message['content'] %}
     {% endif %}
 
     {% if (message['role'] == 'assistant') %}
@@ -22,7 +14,7 @@
         {% set role = message['role'] %}
     {% endif %}
 
-    {{ '<start_of_turn>' + role + '\n' + content | trim + '<end_of_turn>\n' }}
+    {{ '<start_of_turn>' + role + '\n' + message['content'] | trim + '<end_of_turn>\n' }}
 {% endfor %}
 
 {% if add_generation_prompt %}


### PR DESCRIPTION
The [official paper of Gemma](https://arxiv.org/pdf/2403.08295) indicates that it does not support the `system` role. 
![image](https://github.com/chujiezheng/chat_templates/assets/61682147/fd7f090f-7250-408d-bbeb-17b8435df279)

So I replace the template with the official one.
