### PR TITLE
Fix <bos> token in phi-3 template

### DIFF
--- a/chat_templates/phi-3.jinja
+++ b/chat_templates/phi-3.jinja
@@ -4,7 +4,6 @@
     {% set offset = 0 %}
 {% endif %}
 
-{{ bos_token }}
 {% for message in messages %}
     {% if (message['role'] == 'user') != (loop.index0 % 2 == offset) %}
         {{ raise_exception('Conversation roles must alternate user/assistant/user/assistant/...') }}


### PR DESCRIPTION
Phi-3 messages probably shouldn't start with a `<bos>` token. The model has very high loss for this token at position 0 and is much more likely to predict the system token (see plot below, which just shows the per-token loss with a sample prompt), thus I don't think the model has seen the `<bos>` token there during training.

<img width="1180" alt="Screenshot 2024-10-23 at 11 22 51 PM" src="https://github.com/user-attachments/assets/29345d5c-9d54-494d-96a5-43b6d825e158">
